### PR TITLE
Launch properly with SSL, require -port > 0

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,11 +1,11 @@
 {
 	"ImportPath": "github.com/18F/hmacproxy",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.4.3",
 	"Deps": [
 		{
 			"ImportPath": "github.com/18F/hmacauth",
-			"Comment": "0.0.0-pr-1",
-			"Rev": "4b5b37ec51e7a1bb38e342de941697338eaa87f7"
+			"Comment": "0.0.1",
+			"Rev": "42a089d230cce8e6844c503b7f2248d607a3a4b6"
 		},
 		{
 			"ImportPath": "github.com/onsi/ginkgo",

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ signature; uses the [github.com/18F/hmacauth Go package](https://github.com/18F/
 For now, install from source:
 
 ```sh
-$ go get github.com/tools/godep
-$ godep go install -v github.com/18F/hmacproxy
+$ go get github.com/18F/hmacproxy
 ```
 
 ## Testing out locally

--- a/handlers.go
+++ b/handlers.go
@@ -27,7 +27,7 @@ func NewHttpProxyHandler(opts *HmacProxyOpts) (
 }
 
 type signingHandler struct {
-	auth    *hmacauth.HmacAuth
+	auth    hmacauth.HmacAuth
 	handler http.Handler
 }
 
@@ -36,7 +36,7 @@ func (h signingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.handler.ServeHTTP(w, r)
 }
 
-func signAndProxyHandler(auth *hmacauth.HmacAuth, upstream *HmacProxyUrl) (
+func signAndProxyHandler(auth hmacauth.HmacAuth, upstream *HmacProxyUrl) (
 	handler http.Handler, description string) {
 	description = "proxying signed requests to: " + upstream.Raw
 	proxy := httputil.NewSingleHostReverseProxy(upstream.Url)
@@ -45,20 +45,20 @@ func signAndProxyHandler(auth *hmacauth.HmacAuth, upstream *HmacProxyUrl) (
 }
 
 type authHandler struct {
-	auth    *hmacauth.HmacAuth
+	auth    hmacauth.HmacAuth
 	handler http.Handler
 }
 
 func (h authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	result, _, _ := h.auth.ValidateRequest(r)
-	if result != hmacauth.MATCH {
+	if result != hmacauth.ResultMatch {
 		http.Error(w, "unauthorized request", http.StatusUnauthorized)
 	} else {
 		h.handler.ServeHTTP(w, r)
 	}
 }
 
-func authAndProxyHandler(auth *hmacauth.HmacAuth, upstream *HmacProxyUrl) (
+func authAndProxyHandler(auth hmacauth.HmacAuth, upstream *HmacProxyUrl) (
 	handler http.Handler, description string) {
 	description = "proxying authenticated requests to: " + upstream.Raw
 	proxy := httputil.NewSingleHostReverseProxy(upstream.Url)
@@ -66,7 +66,7 @@ func authAndProxyHandler(auth *hmacauth.HmacAuth, upstream *HmacProxyUrl) (
 	return
 }
 
-func authForFilesHandler(auth *hmacauth.HmacAuth, fileRoot string) (
+func authForFilesHandler(auth hmacauth.HmacAuth, fileRoot string) (
 	handler http.Handler, description string) {
 	description = "serving files from " + fileRoot +
 		" for authenticated requests"
@@ -76,19 +76,19 @@ func authForFilesHandler(auth *hmacauth.HmacAuth, fileRoot string) (
 }
 
 type authOnlyHandler struct {
-	auth *hmacauth.HmacAuth
+	auth hmacauth.HmacAuth
 }
 
 func (h authOnlyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	result, _, _ := h.auth.ValidateRequest(r)
-	if result != hmacauth.MATCH {
+	if result != hmacauth.ResultMatch {
 		http.Error(w, "unauthorized request", http.StatusUnauthorized)
 	} else {
 		w.WriteHeader(http.StatusAccepted)
 	}
 }
 
-func authenticationOnlyHandler(auth *hmacauth.HmacAuth) (
+func authenticationOnlyHandler(auth hmacauth.HmacAuth) (
 	handler http.Handler, description string) {
 	description = "responding Accepted/Unauthorized for auth queries"
 	handler = authOnlyHandler{auth}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -16,6 +16,12 @@ func newHandler(flags *flag.FlagSet, opts *HmacProxyOpts,
 	if err := flags.Parse(argv); err != nil {
 		panic("error parsing argv: " + err.Error())
 	}
+
+	// The full command-line program requires that -port be greater than
+	// zero, but the test servers will pick ports dynamically. To avoid
+	// having useless -port arguments in the test, we'll add a fake
+	// argument here.
+	opts.Port = 1
 	if err := opts.Validate(); err != nil {
 		panic("error parsing options: " + err.Error())
 	}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -24,7 +24,7 @@ func newHandler(flags *flag.FlagSet, opts *HmacProxyOpts,
 	if err := opts.Validate(); err != nil {
 		panic("error parsing options: " + err.Error())
 	}
-	return NewHttpProxyHandler(opts)
+	return NewHTTPProxyHandler(opts)
 }
 
 type proxiedServer struct {
@@ -32,7 +32,7 @@ type proxiedServer struct {
 }
 
 func (ps proxiedServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte("Success!"))
+	_, _ = w.Write([]byte("Success!"))
 }
 
 var _ = Describe("HmacProxy Handlers", func() {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,8 +1,7 @@
-package main_test
+package main
 
 import (
 	"flag"
-	. "github.com/18F/hmacproxy"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"io/ioutil"

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"net"
 	"net/http"
 	"strconv"
 )
@@ -16,22 +15,16 @@ func main() {
 		log.Fatal(err)
 	}
 
-	address := "localhost:" + strconv.Itoa(opts.Port)
-
-	listener, err := net.Listen("tcp", address)
-	if err != nil {
-		log.Fatal("listening on " + address + " failed: " + err.Error())
-	}
-	defer listener.Close()
-	address = listener.Addr().String()
-
+	address := ":" + strconv.Itoa(opts.Port)
 	handler, description := NewHttpProxyHandler(opts)
 	server := &http.Server{Addr: address, Handler: handler}
-	fmt.Printf("%s: %s\n", address, description)
+	fmt.Printf("port %d: %s\n", opts.Port, description)
 
+	var err error
 	if opts.SslCert != "" {
-		http.ListenAndServeTLS(address, opts.SslCert, opts.SslKey, handler)
+		err = server.ListenAndServeTLS(opts.SslCert, opts.SslKey)
 	} else {
-		server.Serve(listener)
+		err = server.ListenAndServe()
 	}
+	log.Fatal(err)
 }

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	}
 
 	address := ":" + strconv.Itoa(opts.Port)
-	handler, description := NewHttpProxyHandler(opts)
+	handler, description := NewHTTPProxyHandler(opts)
 	server := &http.Server{Addr: address, Handler: handler}
 	fmt.Printf("port %d: %s\n", opts.Port, description)
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-package main_test
+package main
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/options.go
+++ b/options.go
@@ -7,7 +7,6 @@ import (
 	"github.com/18F/hmacauth"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 )
 
@@ -115,8 +114,9 @@ func validateMode(opts *HmacProxyOpts, msgs []string) []string {
 }
 
 func validatePort(opts *HmacProxyOpts, msgs []string) []string {
-	if opts.Port < 0 {
-		msgs = append(msgs, "invalid port: "+strconv.Itoa(opts.Port))
+	if opts.Port <= 0 {
+		msgs = append(msgs, "port must be specified and " +
+			"greater than zero")
 	}
 	return msgs
 }

--- a/options.go
+++ b/options.go
@@ -99,23 +99,21 @@ func validateMode(opts *HmacProxyOpts, msgs []string) []string {
 		msgs = append(msgs, "-auth must be specified with -file-root")
 	}
 
-	if opts.Auth {
-		if upstreamDefined {
-			opts.Mode = AUTH_AND_PROXY
-		} else if fileRootDefined {
-			opts.Mode = AUTH_FOR_FILES
-		} else {
-			opts.Mode = AUTH_ONLY
-		}
-	} else {
+	if !opts.Auth {
 		opts.Mode = SIGN_AND_PROXY
+	} else if upstreamDefined {
+		opts.Mode = AUTH_AND_PROXY
+	} else if fileRootDefined {
+		opts.Mode = AUTH_FOR_FILES
+	} else {
+		opts.Mode = AUTH_ONLY
 	}
 	return msgs
 }
 
 func validatePort(opts *HmacProxyOpts, msgs []string) []string {
 	if opts.Port <= 0 {
-		msgs = append(msgs, "port must be specified and " +
+		msgs = append(msgs, "port must be specified and "+
 			"greater than zero")
 	}
 	return msgs

--- a/options_test.go
+++ b/options_test.go
@@ -42,9 +42,9 @@ var _ = Describe("HmacProxyOpts", func() {
 			Expect(opts.SignHeader).To(Equal("Test-Signature"))
 			Expect(opts.Upstream.Raw).To(Equal(
 				"https://localhost:8080/"))
-			Expect(opts.Upstream.Url.String()).To(Equal(
+			Expect(opts.Upstream.URL.String()).To(Equal(
 				"https://localhost:8080/"))
-			Expect(opts.Mode).To(Equal(SIGN_AND_PROXY))
+			Expect(opts.Mode).To(Equal(HandlerSignAndProxy))
 		})
 
 		It("should set auth-and-proxy mode using defaults", func() {
@@ -58,7 +58,7 @@ var _ = Describe("HmacProxyOpts", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = opts.Validate()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(opts.Mode).To(Equal(AUTH_AND_PROXY))
+			Expect(opts.Mode).To(Equal(HandlerAuthAndProxy))
 		})
 
 		It("should set auth-for-files mode using defaults", func() {
@@ -73,7 +73,7 @@ var _ = Describe("HmacProxyOpts", func() {
 			err = opts.Validate()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(opts.FileRoot).To(Equal("."))
-			Expect(opts.Mode).To(Equal(AUTH_FOR_FILES))
+			Expect(opts.Mode).To(Equal(HandlerAuthForFiles))
 		})
 
 		It("should set auth-only mode using defaults", func() {
@@ -86,7 +86,7 @@ var _ = Describe("HmacProxyOpts", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = opts.Validate()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(opts.Mode).To(Equal(AUTH_ONLY))
+			Expect(opts.Mode).To(Equal(HandlerAuthOnly))
 		})
 
 		It("should accept default overrides", func() {
@@ -102,10 +102,10 @@ var _ = Describe("HmacProxyOpts", func() {
 			err = opts.Validate()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(opts.Digest.Name).To(Equal("md5"))
-			Expect(opts.Digest.Id).To(Equal(crypto.MD5))
+			Expect(opts.Digest.ID).To(Equal(crypto.MD5))
 			Expect([]string(opts.Headers)).To(Equal([]string{
 				"Content-Type", "Date", "Gap-Auth"}))
-			Expect(opts.Mode).To(Equal(AUTH_ONLY))
+			Expect(opts.Mode).To(Equal(HandlerAuthOnly))
 		})
 
 		It("should accept SSL options", func() {
@@ -125,9 +125,8 @@ var _ = Describe("HmacProxyOpts", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(opts.SslCert).To(Equal(filename))
 			Expect(opts.SslKey).To(Equal(filename))
-			Expect(opts.Mode).To(Equal(AUTH_ONLY))
+			Expect(opts.Mode).To(Equal(HandlerAuthOnly))
 		})
-
 	})
 
 	Context("with an invalid configuration", func() {

--- a/options_test.go
+++ b/options_test.go
@@ -1,9 +1,8 @@
-package main_test
+package main
 
 import (
 	"crypto"
 	"flag"
-	. "github.com/18F/hmacproxy"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"os"

--- a/options_test.go
+++ b/options_test.go
@@ -30,6 +30,7 @@ var _ = Describe("HmacProxyOpts", func() {
 	Context("with a valid configuration", func() {
 		It("should set sign-and-proxy mode using defaults", func() {
 			err := flags.Parse([]string{
+				"-port=8080",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-upstream=https://localhost:8080/",
@@ -37,6 +38,7 @@ var _ = Describe("HmacProxyOpts", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = opts.Validate()
 			Expect(err).NotTo(HaveOccurred())
+			Expect(opts.Port).To(Equal(8080))
 			Expect(opts.Secret).To(Equal("foobar"))
 			Expect(opts.SignHeader).To(Equal("Test-Signature"))
 			Expect(opts.Upstream.Raw).To(Equal(
@@ -48,6 +50,7 @@ var _ = Describe("HmacProxyOpts", func() {
 
 		It("should set auth-and-proxy mode using defaults", func() {
 			err := flags.Parse([]string{
+				"-port=8080",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-upstream=https://localhost:8080/",
@@ -61,6 +64,7 @@ var _ = Describe("HmacProxyOpts", func() {
 
 		It("should set auth-for-files mode using defaults", func() {
 			err := flags.Parse([]string{
+				"-port=8080",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-file-root=.",
@@ -75,6 +79,7 @@ var _ = Describe("HmacProxyOpts", func() {
 
 		It("should set auth-only mode using defaults", func() {
 			err := flags.Parse([]string{
+				"-port=8080",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-auth",
@@ -87,17 +92,16 @@ var _ = Describe("HmacProxyOpts", func() {
 
 		It("should accept default overrides", func() {
 			err := flags.Parse([]string{
+				"-port=8080",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-auth",
-				"-port=8080",
 				"-digest=md5",
 				"-headers=Content-Type,Date,Gap-Auth",
 			})
 			Expect(err).NotTo(HaveOccurred())
 			err = opts.Validate()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(opts.Port).To(Equal(8080))
 			Expect(opts.Digest.Name).To(Equal("md5"))
 			Expect(opts.Digest.Id).To(Equal(crypto.MD5))
 			Expect([]string(opts.Headers)).To(Equal([]string{
@@ -110,6 +114,7 @@ var _ = Describe("HmacProxyOpts", func() {
 			cwd, _ := os.Getwd()
 			filename := filepath.Join(cwd, "options_test.go")
 			err := flags.Parse([]string{
+				"-port=8080",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-auth",
@@ -135,6 +140,7 @@ var _ = Describe("HmacProxyOpts", func() {
 			Expect(err.Error()).To(Equal(optionErrors([]string{
 				"neither -upstream, -file-root, nor -auth " +
 					"specified",
+				"port must be specified and greater than zero",
 				"no secret specified",
 				"no signature header specified",
 			})))
@@ -142,6 +148,7 @@ var _ = Describe("HmacProxyOpts", func() {
 
 		It("should report all file root errors", func() {
 			err := flags.Parse([]string{
+				"-port=8080",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-upstream=http://localhost",
@@ -159,6 +166,7 @@ var _ = Describe("HmacProxyOpts", func() {
 
 		It("should report port and hash digest errors", func() {
 			err := flags.Parse([]string{
+				"-port=-1",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-upstream=http://localhost",
@@ -169,13 +177,14 @@ var _ = Describe("HmacProxyOpts", func() {
 			err = opts.Validate()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal(optionErrors([]string{
-				"invalid port: -1",
+				"port must be specified and greater than zero",
 				"unsupported digest: unsupported",
 			})))
 		})
 
 		It("should report incomplete upstream spec errors", func() {
 			err := flags.Parse([]string{
+				"-port=8080",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-upstream=/",
@@ -191,6 +200,7 @@ var _ = Describe("HmacProxyOpts", func() {
 
 		It("should report incorrect upstream spec errors", func() {
 			err := flags.Parse([]string{
+				"-port=8080",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-upstream=gopher://foo.com/bar/",
@@ -206,6 +216,7 @@ var _ = Describe("HmacProxyOpts", func() {
 
 		It("should report incorrect upstream spec errors", func() {
 			err := flags.Parse([]string{
+				"-port=8080",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-upstream=gopher://foo.com/bar/",
@@ -221,6 +232,7 @@ var _ = Describe("HmacProxyOpts", func() {
 
 		It("should report missing ssl-key option", func() {
 			err := flags.Parse([]string{
+				"-port=8080",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-upstream=https://localhost:8080/",
@@ -238,6 +250,7 @@ var _ = Describe("HmacProxyOpts", func() {
 
 		It("should report missing ssl-cert option", func() {
 			err := flags.Parse([]string{
+				"-port=8080",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-upstream=https://localhost:8080/",
@@ -255,6 +268,7 @@ var _ = Describe("HmacProxyOpts", func() {
 
 		It("should report missing ssl-cert and ssl-key errors", func() {
 			err := flags.Parse([]string{
+				"-port=8080",
 				"-secret=foobar",
 				"-sign-header=Test-Signature",
 				"-upstream=https://localhost:8080/",


### PR DESCRIPTION
The previous version tried to allow -port=0 as a valid option so that a listening port could be allocated dynamically and logged. However, using http.Server.ListenAndServeTLS() doesn't provide a way to extract the dynamic address.

Rather than reimplement parts of http.Server.ListenAndServeTLS(), the -port argument is no longer optional. This has the benefit of allowing the use of http.server.ListenAndServe() in non-SSL mode as well, eliminating the need for manual net.Listener setup.

I've actually manually run this on team-api.18f.gov to confirm I can serve SSL directly from this proxy with these changes, and trying to connect over http rather than https is unsuccessful (returns a 500).

This also updates the README, bumps github.com/18F/hmacauth to v0.0.1, and fixes a bunch of `golint` errors.

cc: @jcscottiii 
